### PR TITLE
Implement MCP server with stdio transport

### DIFF
--- a/packages/sdk/src/store.ts
+++ b/packages/sdk/src/store.ts
@@ -227,11 +227,9 @@ class JSONStore implements Store {
     }
 
     // Check for fast path: single type, simple ID-based filter, no sort/projection
-    let _usedFastPath = false;
     if (spec.type && !spec.sort && !spec.projection && this.canUseFastPath(spec.filter)) {
       const ids = this.extractIdsFromFilter(spec.filter);
       if (ids) {
-        _usedFastPath = true;
         const docs: Document[] = [];
 
         for (const id of ids) {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -14,11 +14,15 @@
   "scripts": {
     "build": "tsc",
     "clean": "rm -rf dist *.tsbuildinfo",
-    "dev": "tsc --watch",
+    "dev": "tsx src/server.ts",
     "start": "node dist/server.js",
     "test": "vitest run",
     "test:watch": "vitest",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "mcp:inspect": "npx @modelcontextprotocol/inspector node dist/server.js"
+  },
+  "engines": {
+    "node": ">=18"
   },
   "keywords": [
     "json",
@@ -31,10 +35,12 @@
   "license": "MIT",
   "dependencies": {
     "@jsonstore/sdk": "workspace:*",
-    "@modelcontextprotocol/sdk": "^1.0.4"
+    "@modelcontextprotocol/sdk": "^1.0.4",
+    "zod": "^4.1.12"
   },
   "devDependencies": {
     "@types/node": "^20.11.0",
+    "tsx": "^4.20.6",
     "typescript": "^5.3.3",
     "vitest": "^1.2.0"
   }

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -2,4 +2,4 @@
  * Server library exports
  */
 
-export { tools } from "./tools.js";
+export { toolDefinitions, toolHandlers } from "./tools.js";

--- a/packages/server/src/observability/logger.ts
+++ b/packages/server/src/observability/logger.ts
@@ -1,0 +1,83 @@
+/**
+ * Structured logging to stderr for MCP server observability
+ * All logs go to stderr since stdout is reserved for MCP protocol
+ */
+
+export type LogLevel = "debug" | "info" | "warn" | "error";
+
+export interface LogEvent {
+  ts: string;
+  level: LogLevel;
+  event: string;
+  tool?: string;
+  duration_ms?: number;
+  err_code?: string;
+  err_message?: string;
+  [key: string]: any;
+}
+
+export class Logger {
+  #minLevel: LogLevel;
+
+  constructor(minLevel: LogLevel = "info") {
+    this.#minLevel = minLevel;
+  }
+
+  private shouldLog(level: LogLevel): boolean {
+    const levels: LogLevel[] = ["debug", "info", "warn", "error"];
+    const minIndex = levels.indexOf(this.#minLevel);
+    const currentIndex = levels.indexOf(level);
+    return currentIndex >= minIndex;
+  }
+
+  private log(level: LogLevel, event: string, data?: Record<string, any>): void {
+    if (!this.shouldLog(level)) {
+      return;
+    }
+
+    const logEvent: LogEvent = {
+      ts: new Date().toISOString(),
+      level,
+      event,
+      ...data,
+    };
+
+    // Always use stderr to avoid polluting stdout (MCP protocol channel)
+    console.error(JSON.stringify(logEvent));
+  }
+
+  debug(event: string, data?: Record<string, any>): void {
+    this.log("debug", event, data);
+  }
+
+  info(event: string, data?: Record<string, any>): void {
+    this.log("info", event, data);
+  }
+
+  warn(event: string, data?: Record<string, any>): void {
+    this.log("warn", event, data);
+  }
+
+  error(event: string, data?: Record<string, any>): void {
+    this.log("error", event, data);
+  }
+
+  // Helper for tool execution logging
+  toolCall(tool: string, duration_ms: number, success: boolean, err?: Error): void {
+    if (success) {
+      this.info("tool.success", { tool, duration_ms });
+    } else {
+      this.error("tool.error", {
+        tool,
+        duration_ms,
+        err_code: (err as any)?.code || "UNKNOWN",
+        err_message: err?.message || String(err),
+      });
+    }
+  }
+}
+
+// Singleton logger instance
+export const logger = new Logger(
+  process.env.LOG_LEVEL === "debug" ? "debug" : "info"
+);

--- a/packages/server/src/observability/metrics.ts
+++ b/packages/server/src/observability/metrics.ts
@@ -1,0 +1,141 @@
+/**
+ * In-process metrics for monitoring tool performance
+ * Tracks call counts, errors, and latency histograms
+ */
+
+interface Counter {
+  count: number;
+}
+
+interface Histogram {
+  values: number[];
+  sum: number;
+  count: number;
+}
+
+class MetricsRegistry {
+  #counters: Map<string, Counter> = new Map();
+  #histograms: Map<string, Histogram> = new Map();
+
+  // Increment a counter
+  inc(name: string, labels: Record<string, string> = {}): void {
+    const key = this.makeKey(name, labels);
+    const counter = this.#counters.get(key) || { count: 0 };
+    counter.count++;
+    this.#counters.set(key, counter);
+  }
+
+  // Observe a value in a histogram
+  observe(name: string, value: number, labels: Record<string, string> = {}): void {
+    const key = this.makeKey(name, labels);
+    const histogram = this.#histograms.get(key) || { values: [], sum: 0, count: 0 };
+    histogram.values.push(value);
+    histogram.sum += value;
+    histogram.count++;
+
+    // Keep only last 1000 values to prevent unbounded memory growth
+    if (histogram.values.length > 1000) {
+      const removed = histogram.values.shift();
+      if (removed !== undefined) {
+        histogram.sum -= removed;
+      }
+      histogram.count = histogram.values.length;
+    }
+
+    this.#histograms.set(key, histogram);
+  }
+
+  // Get counter value
+  getCounter(name: string, labels: Record<string, string> = {}): number {
+    const key = this.makeKey(name, labels);
+    return this.#counters.get(key)?.count || 0;
+  }
+
+  // Get histogram stats (p50, p95, p99)
+  getHistogram(name: string, labels: Record<string, string> = {}): {
+    count: number;
+    sum: number;
+    p50: number;
+    p95: number;
+    p99: number;
+  } | null {
+    const key = this.makeKey(name, labels);
+    const histogram = this.#histograms.get(key);
+    if (!histogram || histogram.values.length === 0) {
+      return null;
+    }
+
+    const sorted = [...histogram.values].sort((a, b) => a - b);
+    const percentile = (p: number) => {
+      const index = Math.ceil((p / 100) * sorted.length) - 1;
+      return sorted[Math.max(0, index)];
+    };
+
+    return {
+      count: histogram.count,
+      sum: histogram.sum,
+      p50: percentile(50),
+      p95: percentile(95),
+      p99: percentile(99),
+    };
+  }
+
+  // Get all metrics (for debugging)
+  getAllMetrics(): {
+    counters: Record<string, number>;
+    histograms: Record<string, any>;
+  } {
+    const counters: Record<string, number> = {};
+    for (const [key, counter] of this.#counters) {
+      counters[key] = counter.count;
+    }
+
+    const histograms: Record<string, any> = {};
+    for (const [key] of this.#histograms) {
+      histograms[key] = this.getHistogram(key.split("{")[0], this.parseLabels(key));
+    }
+
+    return { counters, histograms };
+  }
+
+  private makeKey(name: string, labels: Record<string, string>): string {
+    const labelStr = Object.entries(labels)
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([k, v]) => `${k}="${v}"`)
+      .join(",");
+    return labelStr ? `${name}{${labelStr}}` : name;
+  }
+
+  private parseLabels(key: string): Record<string, string> {
+    const match = key.match(/\{(.+)\}/);
+    if (!match) return {};
+
+    const labels: Record<string, string> = {};
+    for (const pair of match[1].split(",")) {
+      const [k, v] = pair.split("=");
+      labels[k] = v.replace(/"/g, "");
+    }
+    return labels;
+  }
+}
+
+export const metrics = new MetricsRegistry();
+
+// Helper to record tool execution metrics
+export function recordToolExecution(
+  tool: string,
+  duration_ms: number,
+  success: boolean,
+  errCode?: string
+): void {
+  // Increment call counter
+  metrics.inc("jsonstore.tool.calls_total", { tool });
+
+  // Increment error counter if failed
+  if (!success) {
+    metrics.inc("jsonstore.tool.errors_total", { tool, err_code: errCode || "UNKNOWN" });
+  }
+
+  // Record latency
+  metrics.observe("jsonstore.tool.latency_ms", duration_ms, { tool });
+}

--- a/packages/server/src/schemas.ts
+++ b/packages/server/src/schemas.ts
@@ -1,0 +1,196 @@
+/**
+ * Zod schemas for validating tool inputs and outputs
+ * Provides runtime type safety and detailed validation errors
+ */
+
+import { z } from "zod";
+
+// Secure patterns that prevent path traversal
+const typePattern = /^[a-z0-9]+(?:[._-][a-z0-9]+)*$/;
+const idPattern = /^[A-Za-z0-9]+(?:[._-][A-Za-z0-9]+)*$/;
+
+const TypeStringSchema = z.string().min(1).superRefine((val, ctx) => {
+  if (!typePattern.test(val)) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "type must start with alphanumeric and contain only lowercase letters, numbers, dots, underscores, and hyphens",
+    });
+  }
+});
+
+const IdStringSchema = z.string().min(1).superRefine((val, ctx) => {
+  if (!idPattern.test(val)) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "id must start with alphanumeric and contain only letters, numbers, dots, underscores, and hyphens",
+    });
+  }
+});
+
+// Key schema - type and id must be non-empty strings
+export const KeySchema = z.object({
+  type: TypeStringSchema,
+  id: IdStringSchema,
+});
+
+// Document schema - any record with at least type and id fields
+export const DocumentSchema = z.record(z.string(), z.any()).superRefine((doc, ctx) => {
+  if (typeof doc.type !== "string" || !typePattern.test(doc.type)) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["type"],
+      message: "Document must include 'type' field matching the key format",
+    });
+  }
+  if (typeof doc.id !== "string" || !idPattern.test(doc.id)) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["id"],
+      message: "Document must include 'id' field matching the key format",
+    });
+  }
+});
+
+// Commit options schema
+export const CommitSchema = z
+  .object({
+    message: z.string().min(1, "commit message must be non-empty"),
+    batch: z.string().optional(),
+  })
+  .optional();
+
+// Projection schema - all values must be 0 or 1, and cannot mix both
+export const ProjectionSchema = z.record(z.string(), z.union([z.literal(0), z.literal(1)])).superRefine((proj, ctx) => {
+  const values = Object.values(proj);
+  if (values.length === 0) return;
+  const hasZero = values.includes(0);
+  const hasOne = values.includes(1);
+  if (hasZero && hasOne) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "Projection cannot mix 0 and 1 values",
+    });
+  }
+});
+
+// Sort schema - all values must be 1 or -1
+export const SortSchema = z.record(z.string(), z.union([z.literal(1), z.literal(-1)]));
+
+// Filter schema - can be any object (Mango query operators)
+export const FilterSchema = z.record(z.string(), z.any());
+
+// Query spec schema with validation and defaults
+export const QuerySpecSchema = z.object({
+  type: TypeStringSchema.optional(),
+  filter: FilterSchema,
+  projection: ProjectionSchema.optional(),
+  sort: SortSchema.optional(),
+  limit: z
+    .number()
+    .int()
+    .positive()
+    .superRefine((val, ctx) => {
+      if (val > 1000) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "limit cannot exceed 1000",
+        });
+      }
+    })
+    .default(100),
+  skip: z
+    .number()
+    .int()
+    .min(0)
+    .superRefine((val, ctx) => {
+      if (val > 10000) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "skip cannot exceed 10000",
+        });
+      }
+    })
+    .default(0),
+});
+
+// Tool input schemas
+
+export const GetDocInputSchema = z.object({
+  type: TypeStringSchema,
+  id: IdStringSchema,
+});
+
+export const PutDocInputSchema = z.object({
+  type: TypeStringSchema,
+  id: IdStringSchema,
+  doc: DocumentSchema,
+  commit: CommitSchema,
+});
+
+export const RemoveDocInputSchema = z.object({
+  type: TypeStringSchema,
+  id: IdStringSchema,
+  commit: CommitSchema,
+});
+
+export const ListIdsInputSchema = z.object({
+  type: TypeStringSchema,
+});
+
+export const QueryInputSchema = QuerySpecSchema;
+
+export const EnsureIndexInputSchema = z.object({
+  type: TypeStringSchema,
+  field: z.string().min(1).superRefine((val, ctx) => {
+    if (!/^[a-zA-Z0-9._-]+$/.test(val)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "field must be a valid field name (letters, numbers, dots, underscores, hyphens)",
+      });
+    }
+  }),
+});
+
+// Tool output schemas (for documentation)
+
+export const GetDocOutputSchema = z.object({
+  doc: DocumentSchema.nullable(),
+});
+
+export const PutDocOutputSchema = z.object({
+  ok: z.boolean(),
+});
+
+export const RemoveDocOutputSchema = z.object({
+  ok: z.boolean(),
+});
+
+export const ListIdsOutputSchema = z.object({
+  ids: z.array(z.string()),
+  count: z.number().int().min(0),
+});
+
+export const QueryOutputSchema = z.object({
+  results: z.array(DocumentSchema),
+  count: z.number().int().min(0),
+});
+
+export const EnsureIndexOutputSchema = z.object({
+  ok: z.boolean(),
+});
+
+// Export types
+export type Key = z.infer<typeof KeySchema>;
+export type Document = z.infer<typeof DocumentSchema>;
+export type Commit = z.infer<typeof CommitSchema>;
+export type Projection = z.infer<typeof ProjectionSchema>;
+export type Sort = z.infer<typeof SortSchema>;
+export type Filter = z.infer<typeof FilterSchema>;
+export type QuerySpec = z.infer<typeof QuerySpecSchema>;
+
+export type GetDocInput = z.infer<typeof GetDocInputSchema>;
+export type PutDocInput = z.infer<typeof PutDocInputSchema>;
+export type RemoveDocInput = z.infer<typeof RemoveDocInputSchema>;
+export type ListIdsInput = z.infer<typeof ListIdsInputSchema>;
+export type QueryInput = z.infer<typeof QueryInputSchema>;
+export type EnsureIndexInput = z.infer<typeof EnsureIndexInputSchema>;

--- a/packages/server/src/service/jsonstore.ts
+++ b/packages/server/src/service/jsonstore.ts
@@ -1,0 +1,111 @@
+/**
+ * JSON Store service adapter
+ * Wraps the @jsonstore/sdk Store with additional validation and safety limits
+ */
+
+import { openStore } from "@jsonstore/sdk";
+import type { Store as SDKStore, Key, Document, QuerySpec, WriteOptions } from "@jsonstore/sdk";
+import { logger } from "../observability/logger.js";
+
+// Maximum document size in bytes (1MB)
+const MAX_DOCUMENT_SIZE = 1024 * 1024;
+
+// Maximum number of IDs to return from list (prevent unbounded memory)
+const MAX_LIST_IDS = 5000;
+
+export class JsonStoreService {
+  #store: SDKStore;
+
+  constructor(dataRoot: string) {
+    this.#store = openStore({ root: dataRoot });
+    logger.info("service.init", { data_root: dataRoot });
+  }
+
+  /**
+   * Get a document by key
+   * Returns null if not found (not an error)
+   */
+  async get(key: Key): Promise<Document | null> {
+    return this.#store.get(key);
+  }
+
+  /**
+   * Put (create or update) a document
+   * Validates document size before writing
+   */
+  async put(key: Key, doc: Document, commit?: string): Promise<void> {
+    // Validate document size to prevent memory/disk abuse
+    const docStr = JSON.stringify(doc);
+    const docByteLength = Buffer.byteLength(docStr, "utf8");
+    if (docByteLength > MAX_DOCUMENT_SIZE) {
+      throw new Error(
+        `Document too large: ${docByteLength} bytes exceeds limit of ${MAX_DOCUMENT_SIZE} bytes`
+      );
+    }
+
+    const opts: WriteOptions = commit ? { gitCommit: commit } : {};
+    await this.#store.put(key, doc, opts);
+  }
+
+  /**
+   * Remove a document
+   * Idempotent - does not error if document doesn't exist
+   */
+  async remove(key: Key, commit?: string): Promise<void> {
+    try {
+      const opts: WriteOptions = commit ? { gitCommit: commit } : {};
+      await this.#store.remove(key, opts);
+    } catch (err: any) {
+      // Make deletion idempotent - if document doesn't exist, that's ok
+      if (err.code === "ENOENT" || err.message?.includes("not found")) {
+        logger.debug("service.remove.not_found", { key });
+        return;
+      }
+      throw err;
+    }
+  }
+
+  /**
+   * List all document IDs for a type
+   * Capped at MAX_LIST_IDS to prevent unbounded memory usage
+   */
+  async list(type: string): Promise<string[]> {
+    const ids = await this.#store.list(type);
+
+    // Cap the results to prevent unbounded memory usage
+    if (ids.length > MAX_LIST_IDS) {
+      logger.warn("service.list.capped", {
+        type,
+        total: ids.length,
+        returned: MAX_LIST_IDS
+      });
+      return ids.slice(0, MAX_LIST_IDS);
+    }
+
+    return ids;
+  }
+
+  /**
+   * Query documents with Mango query language
+   * Enforces limit and skip bounds
+   */
+  async query(querySpec: QuerySpec): Promise<Document[]> {
+    // QuerySpec already validated by Zod schema with defaults and limits
+    return this.#store.query(querySpec);
+  }
+
+  /**
+   * Ensure an index exists on a field
+   * Idempotent - safe to call multiple times
+   */
+  async ensureIndex(type: string, field: string): Promise<void> {
+    await this.#store.ensureIndex(type, field);
+  }
+}
+
+/**
+ * Singleton service instance
+ * Initialized from DATA_ROOT environment variable
+ */
+const DATA_ROOT = process.env.DATA_ROOT || "./data";
+export const jsonStoreService = new JsonStoreService(DATA_ROOT);

--- a/packages/server/src/test/integration/tools.integration.test.ts
+++ b/packages/server/src/test/integration/tools.integration.test.ts
@@ -1,0 +1,276 @@
+/**
+ * Integration tests for MCP tools
+ * Tests the full flow of tool execution against a real store
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { mkdtemp, rm } from "node:fs/promises";
+import { getDoc, putDoc, removeDoc, listIds, query, ensureIndex } from "../../tools.js";
+
+let testRoot: string;
+
+beforeEach(async () => {
+  // Create temp directory for test data
+  testRoot = await mkdtemp(join(tmpdir(), "jsonstore-test-"));
+  process.env.DATA_ROOT = testRoot;
+});
+
+afterEach(async () => {
+  // Clean up temp directory
+  if (testRoot) {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+describe("Tool integration tests", () => {
+  describe("put_doc and get_doc", () => {
+    it("should store and retrieve a document", async () => {
+      const doc = { type: "task", id: "test-1", title: "Test Task", status: "open" };
+
+      // Put document
+      const putResult = await putDoc({
+        type: "task",
+        id: "test-1",
+        doc,
+      });
+
+      expect(putResult.content).toHaveLength(2);
+      expect(putResult.content[0].type).toBe("text");
+      expect(putResult.content[1].type).toBe("json");
+      expect((putResult.content[1] as any).json.ok).toBe(true);
+
+      // Get document
+      const getResult = await getDoc({ type: "task", id: "test-1" });
+
+      expect(getResult.content).toHaveLength(2);
+      expect(getResult.content[0].type).toBe("text");
+      expect(getResult.content[1].type).toBe("json");
+      expect((getResult.content[1] as any).json.doc).toEqual(doc);
+    });
+
+    it("should return null for non-existent document", async () => {
+      const getResult = await getDoc({ type: "task", id: "non-existent" });
+
+      expect((getResult.content[1] as any).json.doc).toBeNull();
+    });
+
+    it("should update an existing document", async () => {
+      const doc1 = { type: "task", id: "test-1", title: "Test Task", status: "open" };
+      const doc2 = { type: "task", id: "test-1", title: "Updated Task", status: "closed" };
+
+      await putDoc({ type: "task", id: "test-1", doc: doc1 });
+      await putDoc({ type: "task", id: "test-1", doc: doc2 });
+
+      const getResult = await getDoc({ type: "task", id: "test-1" });
+      expect((getResult.content[1] as any).json.doc).toEqual(doc2);
+    });
+  });
+
+  describe("rm_doc", () => {
+    it("should remove a document", async () => {
+      const doc = { type: "task", id: "test-1", title: "Test Task" };
+
+      await putDoc({ type: "task", id: "test-1", doc });
+      await removeDoc({ type: "task", id: "test-1" });
+
+      const getResult = await getDoc({ type: "task", id: "test-1" });
+      expect((getResult.content[1] as any).json.doc).toBeNull();
+    });
+
+    it("should be idempotent (not error on missing doc)", async () => {
+      const result = await removeDoc({ type: "task", id: "non-existent" });
+      expect((result.content[1] as any).json.ok).toBe(true);
+    });
+  });
+
+  describe("list_ids", () => {
+    it("should list all document IDs for a type", async () => {
+      const docs = [
+        { type: "task", id: "task-1", title: "Task 1" },
+        { type: "task", id: "task-2", title: "Task 2" },
+        { type: "task", id: "task-3", title: "Task 3" },
+      ];
+
+      for (const doc of docs) {
+        await putDoc({ type: "task", id: doc.id, doc });
+      }
+
+      const result = await listIds({ type: "task" });
+      const ids = (result.content[1] as any).json.ids;
+
+      expect(ids).toHaveLength(3);
+      expect(ids).toContain("task-1");
+      expect(ids).toContain("task-2");
+      expect(ids).toContain("task-3");
+    });
+
+    it("should return empty array for non-existent type", async () => {
+      const result = await listIds({ type: "non-existent" });
+      const ids = (result.content[1] as any).json.ids;
+
+      expect(ids).toHaveLength(0);
+    });
+  });
+
+  describe("query", () => {
+    beforeEach(async () => {
+      // Create test documents
+      const docs = [
+        { type: "task", id: "task-1", title: "Task 1", status: "open", priority: 1 },
+        { type: "task", id: "task-2", title: "Task 2", status: "closed", priority: 2 },
+        { type: "task", id: "task-3", title: "Task 3", status: "open", priority: 3 },
+        { type: "project", id: "proj-1", name: "Project 1" },
+      ];
+
+      for (const doc of docs) {
+        await putDoc({ type: doc.type, id: doc.id, doc });
+      }
+    });
+
+    it("should filter by simple equality", async () => {
+      const result = await query({
+        filter: { status: "open" },
+      });
+
+      const results = (result.content[1] as any).json.results;
+      expect(results).toHaveLength(2);
+      expect(results.every((d: any) => d.status === "open")).toBe(true);
+    });
+
+    it("should filter by type", async () => {
+      const result = await query({
+        type: "task",
+        filter: {},
+      });
+
+      const results = (result.content[1] as any).json.results;
+      expect(results).toHaveLength(3);
+      expect(results.every((d: any) => d.type === "task")).toBe(true);
+    });
+
+    it("should apply projection", async () => {
+      const result = await query({
+        filter: { type: "task" },
+        projection: { title: 1, status: 1 },
+      });
+
+      const results = (result.content[1] as any).json.results;
+      expect(results.length).toBeGreaterThan(0);
+      // Results should only have title and status fields (plus type/id which are always included)
+      const firstResult = results[0];
+      expect(firstResult).toHaveProperty("title");
+      expect(firstResult).toHaveProperty("status");
+      expect(firstResult).not.toHaveProperty("priority");
+    });
+
+    it("should apply sort", async () => {
+      const result = await query({
+        filter: { type: "task" },
+        sort: { priority: -1 }, // Descending
+      });
+
+      const results = (result.content[1] as any).json.results;
+      expect(results).toHaveLength(3);
+      expect(results[0].priority).toBe(3);
+      expect(results[1].priority).toBe(2);
+      expect(results[2].priority).toBe(1);
+    });
+
+    it("should apply limit", async () => {
+      const result = await query({
+        filter: { type: "task" },
+        limit: 2,
+      });
+
+      const results = (result.content[1] as any).json.results;
+      expect(results).toHaveLength(2);
+    });
+
+    it("should apply skip", async () => {
+      const result = await query({
+        filter: { type: "task" },
+        sort: { id: 1 },
+        skip: 1,
+        limit: 2,
+      });
+
+      const results = (result.content[1] as any).json.results;
+      expect(results).toHaveLength(2);
+      expect(results[0].id).toBe("task-2");
+    });
+
+    it("should use default limit", async () => {
+      const result = await query({
+        filter: { type: "task" },
+      });
+
+      // Should not throw and should apply default limit of 100
+      expect((result.content[1] as any).json.results).toBeDefined();
+    });
+  });
+
+  describe("ensure_index", () => {
+    it.skip("should create an index without error", async () => {
+      // TODO: ensureIndex is not yet implemented in the SDK
+      const result = await ensureIndex({
+        type: "task",
+        field: "status",
+      });
+
+      expect((result.content[1] as any).json.ok).toBe(true);
+    });
+
+    it.skip("should be idempotent", async () => {
+      // TODO: ensureIndex is not yet implemented in the SDK
+      await ensureIndex({ type: "task", field: "status" });
+      const result = await ensureIndex({ type: "task", field: "status" });
+
+      expect((result.content[1] as any).json.ok).toBe(true);
+    });
+  });
+
+  describe("Error handling", () => {
+    it("should reject documents that are too large", async () => {
+      const largeDoc = {
+        type: "task",
+        id: "large-1",
+        data: "x".repeat(2 * 1024 * 1024), // 2MB
+      };
+
+      await expect(
+        putDoc({ type: "task", id: "large-1", doc: largeDoc })
+      ).rejects.toThrow(/too large/);
+    });
+
+    it("should validate document has type and id fields", async () => {
+      await expect(
+        putDoc({
+          type: "task",
+          id: "test-1",
+          doc: { title: "Missing type and id" } as any,
+        })
+      ).rejects.toThrow();
+    });
+
+    it("should enforce query limits", async () => {
+      await expect(
+        query({ filter: {}, limit: 1001 })
+      ).rejects.toThrow(/cannot exceed 1000/);
+
+      await expect(
+        query({ filter: {}, skip: 10001 })
+      ).rejects.toThrow(/cannot exceed 10000/);
+    });
+  });
+
+  describe("Timeout behavior", () => {
+    it("should timeout long-running operations", async () => {
+      // Note: This test is hard to reliably trigger without mocking
+      // In a real scenario, you'd mock the store to simulate slow operations
+      // For now, we just verify the timeout mechanism exists
+      expect(true).toBe(true);
+    });
+  });
+});

--- a/packages/server/src/test/unit/schemas.test.ts
+++ b/packages/server/src/test/unit/schemas.test.ts
@@ -1,0 +1,335 @@
+/**
+ * Unit tests for Zod schemas
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  KeySchema,
+  DocumentSchema,
+  ProjectionSchema,
+  SortSchema,
+  QuerySpecSchema,
+  GetDocInputSchema,
+  PutDocInputSchema,
+  RemoveDocInputSchema,
+  ListIdsInputSchema,
+  QueryInputSchema,
+  EnsureIndexInputSchema,
+} from "../../schemas.js";
+
+describe("KeySchema", () => {
+  it("should accept valid keys", () => {
+    expect(() => KeySchema.parse({ type: "task", id: "123" })).not.toThrow();
+    expect(() => KeySchema.parse({ type: "my-type", id: "my-id_123" })).not.toThrow();
+  });
+
+  it("should reject invalid type (uppercase)", () => {
+    expect(() => KeySchema.parse({ type: "Task", id: "123" })).toThrow();
+  });
+
+  it("should reject invalid id (with spaces)", () => {
+    expect(() => KeySchema.parse({ type: "task", id: "my id" })).toThrow();
+  });
+
+  it("should reject empty strings", () => {
+    expect(() => KeySchema.parse({ type: "", id: "123" })).toThrow();
+    expect(() => KeySchema.parse({ type: "task", id: "" })).toThrow();
+  });
+
+  it("should reject path traversal patterns", () => {
+    expect(() => KeySchema.parse({ type: "../etc", id: "123" })).toThrow(/type/);
+    expect(() => KeySchema.parse({ type: "..", id: "123" })).toThrow(/type/);
+    expect(() => KeySchema.parse({ type: "task", id: "/etc/passwd" })).toThrow(/id/);
+    expect(() => KeySchema.parse({ type: "task", id: ".." })).toThrow(/id/);
+    expect(() => KeySchema.parse({ type: ".hidden", id: "123" })).toThrow(/type/);
+  });
+
+  it("should reject keys starting or ending with separators", () => {
+    expect(() => KeySchema.parse({ type: "-task", id: "123" })).toThrow(/type/);
+    expect(() => KeySchema.parse({ type: "task-", id: "123" })).toThrow(/type/);
+    expect(() => KeySchema.parse({ type: "task", id: "-123" })).toThrow(/id/);
+  });
+});
+
+describe("DocumentSchema", () => {
+  it("should accept valid documents", () => {
+    expect(() =>
+      DocumentSchema.parse({ type: "task", id: "123", title: "Test" })
+    ).not.toThrow();
+  });
+
+  it("should reject documents without type", () => {
+    expect(() => DocumentSchema.parse({ id: "123", title: "Test" })).toThrow();
+  });
+
+  it("should reject documents without id", () => {
+    expect(() => DocumentSchema.parse({ type: "task", title: "Test" })).toThrow();
+  });
+
+  it("should reject documents with empty type or id", () => {
+    expect(() => DocumentSchema.parse({ type: "", id: "123" })).toThrow(/type/);
+    expect(() => DocumentSchema.parse({ type: "task", id: "" })).toThrow(/id/);
+  });
+
+  it("should reject documents with invalid key patterns", () => {
+    expect(() => DocumentSchema.parse({ type: "../etc", id: "123" })).toThrow(/type/);
+    expect(() => DocumentSchema.parse({ type: "task", id: "/etc/passwd" })).toThrow(/id/);
+    expect(() => DocumentSchema.parse({ type: "Task", id: "123" })).toThrow(/type/);
+  });
+});
+
+describe("ProjectionSchema", () => {
+  it("should accept valid projections", () => {
+    expect(() => ProjectionSchema.parse({ title: 1, status: 1 })).not.toThrow();
+    expect(() => ProjectionSchema.parse({ password: 0, secret: 0 })).not.toThrow();
+    expect(() => ProjectionSchema.parse({})).not.toThrow();
+  });
+
+  it("should reject mixed 0 and 1 projections", () => {
+    expect(() => ProjectionSchema.parse({ title: 1, password: 0 })).toThrow(/cannot mix/);
+  });
+});
+
+describe("SortSchema", () => {
+  it("should accept valid sort specifications", () => {
+    expect(() => SortSchema.parse({ title: 1 })).not.toThrow();
+    expect(() => SortSchema.parse({ createdAt: -1 })).not.toThrow();
+    expect(() => SortSchema.parse({ title: 1, createdAt: -1 })).not.toThrow();
+  });
+
+  it("should reject invalid sort values", () => {
+    expect(() => SortSchema.parse({ title: 0 })).toThrow();
+    expect(() => SortSchema.parse({ title: 2 })).toThrow();
+  });
+});
+
+describe("QuerySpecSchema", () => {
+  it("should accept valid query specs with defaults", () => {
+    const result = QuerySpecSchema.parse({ filter: { type: "task" } });
+    expect(result.limit).toBe(100);
+    expect(result.skip).toBe(0);
+  });
+
+  it("should accept custom limit and skip", () => {
+    const result = QuerySpecSchema.parse({
+      filter: { type: "task" },
+      limit: 50,
+      skip: 10,
+    });
+    expect(result.limit).toBe(50);
+    expect(result.skip).toBe(10);
+  });
+
+  it("should reject limit > 1000", () => {
+    expect(() =>
+      QuerySpecSchema.parse({ filter: { type: "task" }, limit: 1001 })
+    ).toThrow(/cannot exceed 1000/);
+  });
+
+  it("should reject skip > 10000", () => {
+    expect(() =>
+      QuerySpecSchema.parse({ filter: { type: "task" }, skip: 10001 })
+    ).toThrow(/cannot exceed 10000/);
+  });
+
+  it("should reject negative limit", () => {
+    expect(() =>
+      QuerySpecSchema.parse({ filter: { type: "task" }, limit: -1 })
+    ).toThrow();
+  });
+
+  it("should reject negative skip", () => {
+    expect(() =>
+      QuerySpecSchema.parse({ filter: { type: "task" }, skip: -1 })
+    ).toThrow();
+  });
+
+  it("should enforce limit/skip boundaries", () => {
+    expect(() => QuerySpecSchema.parse({ filter: {}, limit: 0 })).toThrow();
+    expect(() => QuerySpecSchema.parse({ filter: {}, limit: 1000, skip: 10000 })).not.toThrow();
+  });
+
+  it("should reject path traversal in type", () => {
+    expect(() => QuerySpecSchema.parse({ filter: {}, type: "../etc" })).toThrow(/type/);
+    expect(() => QuerySpecSchema.parse({ filter: {}, type: ".." })).toThrow(/type/);
+  });
+});
+
+describe("Tool input schemas", () => {
+  describe("GetDocInputSchema", () => {
+    it("should accept valid input", () => {
+      expect(() => GetDocInputSchema.parse({ type: "task", id: "123" })).not.toThrow();
+    });
+
+    it("should reject missing fields", () => {
+      expect(() => GetDocInputSchema.parse({ type: "task" })).toThrow();
+      expect(() => GetDocInputSchema.parse({ id: "123" })).toThrow();
+    });
+
+    it("should reject path traversal", () => {
+      expect(() => GetDocInputSchema.parse({ type: "../etc", id: "123" })).toThrow(/type/);
+      expect(() => GetDocInputSchema.parse({ type: "task", id: "/evil" })).toThrow(/id/);
+    });
+  });
+
+  describe("PutDocInputSchema", () => {
+    it("should accept valid input without commit", () => {
+      expect(() =>
+        PutDocInputSchema.parse({
+          type: "task",
+          id: "123",
+          doc: { type: "task", id: "123", title: "Test" },
+        })
+      ).not.toThrow();
+    });
+
+    it("should accept valid input with commit", () => {
+      expect(() =>
+        PutDocInputSchema.parse({
+          type: "task",
+          id: "123",
+          doc: { type: "task", id: "123", title: "Test" },
+          commit: { message: "Add task" },
+        })
+      ).not.toThrow();
+    });
+
+    it("should reject missing doc", () => {
+      expect(() => PutDocInputSchema.parse({ type: "task", id: "123" })).toThrow();
+    });
+
+    it("should reject path traversal in type/id", () => {
+      expect(() =>
+        PutDocInputSchema.parse({
+          type: "../etc",
+          id: "123",
+          doc: { type: "task", id: "123" },
+        })
+      ).toThrow(/type/);
+      expect(() =>
+        PutDocInputSchema.parse({
+          type: "task",
+          id: "/evil",
+          doc: { type: "task", id: "123" },
+        })
+      ).toThrow(/id/);
+    });
+
+    it("should reject invalid document key fields", () => {
+      expect(() =>
+        PutDocInputSchema.parse({
+          type: "task",
+          id: "123",
+          doc: { type: "../etc", id: "123" },
+        })
+      ).toThrow(/Document/);
+      expect(() =>
+        PutDocInputSchema.parse({
+          type: "task",
+          id: "123",
+          doc: { type: "task", id: "/evil" },
+        })
+      ).toThrow(/Document/);
+    });
+
+    it("should reject empty commit message", () => {
+      expect(() =>
+        PutDocInputSchema.parse({
+          type: "task",
+          id: "123",
+          doc: { type: "task", id: "123" },
+          commit: { message: "" },
+        })
+      ).toThrow(/commit message/);
+    });
+  });
+
+  describe("RemoveDocInputSchema", () => {
+    it("should accept valid input", () => {
+      expect(() => RemoveDocInputSchema.parse({ type: "task", id: "123" })).not.toThrow();
+    });
+
+    it("should reject path traversal", () => {
+      expect(() => RemoveDocInputSchema.parse({ type: "../etc", id: "123" })).toThrow(/type/);
+      expect(() => RemoveDocInputSchema.parse({ type: "task", id: "/evil" })).toThrow(/id/);
+    });
+  });
+
+  describe("ListIdsInputSchema", () => {
+    it("should accept valid input", () => {
+      expect(() => ListIdsInputSchema.parse({ type: "task" })).not.toThrow();
+    });
+
+    it("should reject missing type", () => {
+      expect(() => ListIdsInputSchema.parse({})).toThrow();
+    });
+
+    it("should reject path traversal in type", () => {
+      expect(() => ListIdsInputSchema.parse({ type: ".hidden" })).toThrow(/type/);
+      expect(() => ListIdsInputSchema.parse({ type: "../etc" })).toThrow(/type/);
+    });
+  });
+
+  describe("QueryInputSchema", () => {
+    it("should accept minimal query", () => {
+      expect(() => QueryInputSchema.parse({ filter: {} })).not.toThrow();
+    });
+
+    it("should accept full query spec", () => {
+      expect(() =>
+        QueryInputSchema.parse({
+          type: "task",
+          filter: { status: "open" },
+          projection: { title: 1 },
+          sort: { createdAt: -1 },
+          limit: 50,
+          skip: 0,
+        })
+      ).not.toThrow();
+    });
+
+    it("should reject missing filter", () => {
+      expect(() => QueryInputSchema.parse({})).toThrow();
+    });
+
+    it("should reject path traversal in type", () => {
+      expect(() => QueryInputSchema.parse({ filter: {}, type: "../etc" })).toThrow(/type/);
+    });
+  });
+
+  describe("EnsureIndexInputSchema", () => {
+    it("should accept valid input", () => {
+      expect(() =>
+        EnsureIndexInputSchema.parse({ type: "task", field: "status" })
+      ).not.toThrow();
+      expect(() =>
+        EnsureIndexInputSchema.parse({ type: "task", field: "nested.field" })
+      ).not.toThrow();
+    });
+
+    it("should reject invalid field names", () => {
+      expect(() =>
+        EnsureIndexInputSchema.parse({ type: "task", field: "field with spaces" })
+      ).toThrow();
+    });
+
+    it("should reject empty field", () => {
+      expect(() => EnsureIndexInputSchema.parse({ type: "task", field: "" })).toThrow();
+    });
+
+    it("should reject path traversal in type", () => {
+      expect(() =>
+        EnsureIndexInputSchema.parse({ type: "../etc", field: "status" })
+      ).toThrow(/type/);
+    });
+
+    it("should reject path traversal in field", () => {
+      expect(() =>
+        EnsureIndexInputSchema.parse({ type: "task", field: "../path" })
+      ).toThrow();
+      expect(() =>
+        EnsureIndexInputSchema.parse({ type: "task", field: "/leadingSlash" })
+      ).toThrow();
+    });
+  });
+});

--- a/packages/server/src/tools.ts
+++ b/packages/server/src/tools.ts
@@ -1,13 +1,210 @@
 /**
- * MCP tool definitions for JSON Store
+ * MCP tool implementations for JSON Store
+ * All tools follow MCP spec: return content array with text and json items
  */
+
+import {
+  GetDocInputSchema,
+  PutDocInputSchema,
+  RemoveDocInputSchema,
+  ListIdsInputSchema,
+  QueryInputSchema,
+  EnsureIndexInputSchema,
+} from "./schemas.js";
+import { jsonStoreService } from "./service/jsonstore.js";
+import { logger } from "./observability/logger.js";
+import { recordToolExecution } from "./observability/metrics.js";
+import type { Document } from "@jsonstore/sdk";
+
+// Helper to wrap tool execution with timeout, logging, and metrics
+async function executeTool<T>(
+  toolName: string,
+  timeoutMs: number,
+  handler: () => Promise<T>
+): Promise<T> {
+  const startTime = Date.now();
+  let success = false;
+  let error: Error | undefined;
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
+  try {
+    // Create timeout promise
+    const timeoutPromise = new Promise<never>((_, reject) => {
+      timeoutId = setTimeout(() => {
+        const timeoutError = new Error(`Tool execution timeout after ${timeoutMs}ms`);
+        (timeoutError as any).code = "ETIMEDOUT";
+        reject(timeoutError);
+      }, timeoutMs);
+    });
+
+    const handlerPromise = handler();
+
+    // Race between handler and timeout
+    const result = await Promise.race([handlerPromise, timeoutPromise]);
+    success = true;
+    return result;
+  } catch (err) {
+    error = err instanceof Error ? err : new Error(String(err));
+    throw error;
+  } finally {
+    if (timeoutId !== undefined) {
+      clearTimeout(timeoutId);
+    }
+    const duration = Date.now() - startTime;
+    logger.toolCall(toolName, duration, success, error);
+    recordToolExecution(toolName, duration, success, (error as any)?.code);
+  }
+}
 
 /**
- * Tool schemas following MCP specification
- * Each tool has a name, description, and JSON Schema for input
+ * get_doc: Retrieve a document by type and ID
  */
+export async function getDoc(args: unknown) {
+  const { type, id } = GetDocInputSchema.parse(args);
 
-export const tools = [
+  return executeTool("get_doc", 2000, async () => {
+    const doc = await jsonStoreService.get({ type, id });
+
+    return {
+      content: [
+        {
+          type: "text",
+          text: doc ? `Found document ${type}/${id}` : `Document ${type}/${id} not found`,
+        },
+        {
+          type: "json",
+          json: { doc },
+        },
+      ],
+    };
+  });
+}
+
+/**
+ * put_doc: Store or update a document
+ */
+export async function putDoc(args: unknown) {
+  const { type, id, doc, commit } = PutDocInputSchema.parse(args);
+
+  return executeTool("put_doc", 5000, async () => {
+    await jsonStoreService.put({ type, id }, doc as Document, commit?.message);
+
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Stored ${type}/${id}`,
+        },
+        {
+          type: "json",
+          json: { ok: true },
+        },
+      ],
+    };
+  });
+}
+
+/**
+ * rm_doc: Remove a document (idempotent)
+ */
+export async function removeDoc(args: unknown) {
+  const { type, id, commit } = RemoveDocInputSchema.parse(args);
+
+  return executeTool("rm_doc", 5000, async () => {
+    await jsonStoreService.remove({ type, id }, commit?.message);
+
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Removed ${type}/${id}`,
+        },
+        {
+          type: "json",
+          json: { ok: true },
+        },
+      ],
+    };
+  });
+}
+
+/**
+ * list_ids: List all document IDs for a type
+ */
+export async function listIds(args: unknown) {
+  const { type } = ListIdsInputSchema.parse(args);
+
+  return executeTool("list_ids", 2000, async () => {
+    const ids = await jsonStoreService.list(type);
+
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Found ${ids.length} documents of type ${type}`,
+        },
+        {
+          type: "json",
+          json: { ids, count: ids.length },
+        },
+      ],
+    };
+  });
+}
+
+/**
+ * query: Execute a Mango query
+ */
+export async function query(args: unknown) {
+  const querySpec = QueryInputSchema.parse(args);
+
+  return executeTool("query", 5000, async () => {
+    const results = await jsonStoreService.query(querySpec as any);
+
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Found ${results.length} matching documents`,
+        },
+        {
+          type: "json",
+          json: { results, count: results.length },
+        },
+      ],
+    };
+  });
+}
+
+/**
+ * ensure_index: Create or update an index
+ */
+export async function ensureIndex(args: unknown) {
+  const { type, field } = EnsureIndexInputSchema.parse(args);
+
+  return executeTool("ensure_index", 5000, async () => {
+    await jsonStoreService.ensureIndex(type, field);
+
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Index created on ${type}.${field}`,
+        },
+        {
+          type: "json",
+          json: { ok: true },
+        },
+      ],
+    };
+  });
+}
+
+/**
+ * Tool definitions for MCP server
+ * Maps tool names to their schemas and handlers
+ */
+export const toolDefinitions = [
   {
     name: "get_doc",
     description: "Retrieve a document by type and ID",
@@ -34,7 +231,7 @@ export const tools = [
       properties: {
         type: {
           type: "string",
-          description: "Entity type (e.g., 'task', 'project')",
+          description: "Entity type",
         },
         id: {
           type: "string",
@@ -54,7 +251,7 @@ export const tools = [
             },
             batch: {
               type: "string",
-              description: "Batch identifier for grouping multiple commits",
+              description: "Batch identifier for grouping commits",
             },
           },
         },
@@ -64,7 +261,7 @@ export const tools = [
   },
   {
     name: "rm_doc",
-    description: "Remove a document",
+    description: "Remove a document (idempotent - no error if missing)",
     inputSchema: {
       type: "object",
       properties: {
@@ -92,7 +289,7 @@ export const tools = [
   },
   {
     name: "list_ids",
-    description: "List all document IDs for a given type",
+    description: "List all document IDs for a given type (capped at 5000)",
     inputSchema: {
       type: "object",
       properties: {
@@ -106,7 +303,7 @@ export const tools = [
   },
   {
     name: "query",
-    description: "Query documents using Mango query language",
+    description: "Query documents using Mango query language (limit max 1000, default 100)",
     inputSchema: {
       type: "object",
       properties: {
@@ -117,11 +314,11 @@ export const tools = [
         filter: {
           type: "object",
           description:
-            "Mango filter object (supports $eq, $ne, $in, $nin, $gt, $gte, $lt, $lte, $and, $or, $not)",
+            "Mango filter object (supports $eq, $ne, $in, $nin, $gt, $gte, $lt, $lte, $exists, $type, $and, $or, $not)",
         },
         projection: {
           type: "object",
-          description: "Fields to include (1) or exclude (0)",
+          description: "Fields to include (1) or exclude (0) - cannot mix 0 and 1",
         },
         sort: {
           type: "object",
@@ -129,11 +326,11 @@ export const tools = [
         },
         limit: {
           type: "number",
-          description: "Maximum number of results",
+          description: "Maximum number of results (max 1000, default 100)",
         },
         skip: {
           type: "number",
-          description: "Number of results to skip (for pagination)",
+          description: "Number of results to skip (for pagination, max 10000)",
         },
       },
       required: ["filter"],
@@ -141,7 +338,7 @@ export const tools = [
   },
   {
     name: "ensure_index",
-    description: "Create or update an equality index for fast lookups on a field",
+    description: "Create or update an equality index for fast lookups on a field (idempotent)",
     inputSchema: {
       type: "object",
       properties: {
@@ -151,29 +348,22 @@ export const tools = [
         },
         field: {
           type: "string",
-          description: "Field name to index",
+          description: "Field name to index (supports dot notation for nested fields)",
         },
       },
       required: ["type", "field"],
     },
   },
-  {
-    name: "git_commit",
-    description: "Commit staged changes to git (optional tool for explicit control)",
-    inputSchema: {
-      type: "object",
-      properties: {
-        message: {
-          type: "string",
-          description: "Commit message",
-        },
-        add: {
-          type: "array",
-          items: { type: "string" },
-          description: "Optional array of file paths to stage before committing",
-        },
-      },
-      required: ["message"],
-    },
-  },
 ];
+
+/**
+ * Tool handlers map
+ */
+export const toolHandlers = {
+  get_doc: getDoc,
+  put_doc: putDoc,
+  rm_doc: removeDoc,
+  list_ids: listIds,
+  query: query,
+  ensure_index: ensureIndex,
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -94,10 +94,16 @@ importers:
       '@modelcontextprotocol/sdk':
         specifier: ^1.0.4
         version: 1.21.0
+      zod:
+        specifier: ^4.1.12
+        version: 4.1.12
     devDependencies:
       '@types/node':
         specifier: ^20.11.0
         version: 20.19.24
+      tsx:
+        specifier: ^4.20.6
+        version: 4.20.6
       typescript:
         specifier: ^5.3.3
         version: 5.9.3
@@ -292,9 +298,27 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/aix-ppc64@0.25.12:
+    resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/android-arm64@0.21.5:
     resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
     engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/android-arm64@0.25.12:
+    resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
     requiresBuild: true
@@ -310,9 +334,27 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/android-arm@0.25.12:
+    resolution: {integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/android-x64@0.21.5:
     resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/android-x64@0.25.12:
+    resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
     requiresBuild: true
@@ -328,9 +370,27 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/darwin-arm64@0.25.12:
+    resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/darwin-x64@0.21.5:
     resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/darwin-x64@0.25.12:
+    resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
@@ -346,9 +406,27 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/freebsd-arm64@0.25.12:
+    resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/freebsd-x64@0.21.5:
     resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/freebsd-x64@0.25.12:
+    resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
     requiresBuild: true
@@ -364,9 +442,27 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/linux-arm64@0.25.12:
+    resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/linux-arm@0.21.5:
     resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
     engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-arm@0.25.12:
+    resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
+    engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
     requiresBuild: true
@@ -382,9 +478,27 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/linux-ia32@0.25.12:
+    resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/linux-loong64@0.21.5:
     resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
     engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-loong64@0.25.12:
+    resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
+    engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
     requiresBuild: true
@@ -400,9 +514,27 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/linux-mips64el@0.25.12:
+    resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/linux-ppc64@0.21.5:
     resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
     engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-ppc64@0.25.12:
+    resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
+    engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
     requiresBuild: true
@@ -418,9 +550,27 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/linux-riscv64@0.25.12:
+    resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/linux-s390x@0.21.5:
     resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
     engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-s390x@0.25.12:
+    resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
+    engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
     requiresBuild: true
@@ -436,11 +586,47 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/linux-x64@0.25.12:
+    resolution: {integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/netbsd-arm64@0.25.12:
+    resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/netbsd-x64@0.21.5:
     resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [netbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/netbsd-x64@0.25.12:
+    resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/openbsd-arm64@0.25.12:
+    resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
     requiresBuild: true
     dev: true
     optional: true
@@ -454,9 +640,36 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/openbsd-x64@0.25.12:
+    resolution: {integrity: sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/openharmony-arm64@0.25.12:
+    resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/sunos-x64@0.21.5:
     resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/sunos-x64@0.25.12:
+    resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
     requiresBuild: true
@@ -472,6 +685,15 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/win32-arm64@0.25.12:
+    resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/win32-ia32@0.21.5:
     resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
     engines: {node: '>=12'}
@@ -481,9 +703,27 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/win32-ia32@0.25.12:
+    resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/win32-x64@0.21.5:
     resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/win32-x64@0.25.12:
+    resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
     requiresBuild: true
@@ -1469,6 +1709,40 @@ packages:
       '@esbuild/win32-x64': 0.21.5
     dev: true
 
+  /esbuild@0.25.12:
+    resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
+    engines: {node: '>=18'}
+    hasBin: true
+    requiresBuild: true
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.25.12
+      '@esbuild/android-arm': 0.25.12
+      '@esbuild/android-arm64': 0.25.12
+      '@esbuild/android-x64': 0.25.12
+      '@esbuild/darwin-arm64': 0.25.12
+      '@esbuild/darwin-x64': 0.25.12
+      '@esbuild/freebsd-arm64': 0.25.12
+      '@esbuild/freebsd-x64': 0.25.12
+      '@esbuild/linux-arm': 0.25.12
+      '@esbuild/linux-arm64': 0.25.12
+      '@esbuild/linux-ia32': 0.25.12
+      '@esbuild/linux-loong64': 0.25.12
+      '@esbuild/linux-mips64el': 0.25.12
+      '@esbuild/linux-ppc64': 0.25.12
+      '@esbuild/linux-riscv64': 0.25.12
+      '@esbuild/linux-s390x': 0.25.12
+      '@esbuild/linux-x64': 0.25.12
+      '@esbuild/netbsd-arm64': 0.25.12
+      '@esbuild/netbsd-x64': 0.25.12
+      '@esbuild/openbsd-arm64': 0.25.12
+      '@esbuild/openbsd-x64': 0.25.12
+      '@esbuild/openharmony-arm64': 0.25.12
+      '@esbuild/sunos-x64': 0.25.12
+      '@esbuild/win32-arm64': 0.25.12
+      '@esbuild/win32-ia32': 0.25.12
+      '@esbuild/win32-x64': 0.25.12
+    dev: true
+
   /escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
@@ -1802,6 +2076,12 @@ packages:
   /get-stream@8.0.1:
     resolution: {integrity: sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==}
     engines: {node: '>=16'}
+    dev: true
+
+  /get-tsconfig@4.13.0:
+    resolution: {integrity: sha512-1VKTZJCwBrvbd+Wn3AOgQP/2Av+TfTCOlE4AcRJE72W1ksZXbAx8PPBR9RzgTeSPzlPMHrbANMH3LbltH73wxQ==}
+    dependencies:
+      resolve-pkg-maps: 1.0.0
     dev: true
 
   /glob-parent@5.1.2:
@@ -2413,6 +2693,10 @@ packages:
     engines: {node: '>=4'}
     dev: true
 
+  /resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+    dev: true
+
   /reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
@@ -2693,6 +2977,17 @@ packages:
       typescript: 5.9.3
     dev: true
 
+  /tsx@4.20.6:
+    resolution: {integrity: sha512-ytQKuwgmrrkDTFP4LjR0ToE2nqgy886GpvRSpU0JAnrdBYppuY5rLkRUYPU1yCryb24SsKBTL/hlDQAEFVwtZg==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+    dependencies:
+      esbuild: 0.25.12
+      get-tsconfig: 4.13.0
+    optionalDependencies:
+      fsevents: 2.3.3
+    dev: true
+
   /type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
@@ -2926,4 +3221,8 @@ packages:
 
   /zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+    dev: false
+
+  /zod@4.1.12:
+    resolution: {integrity: sha512-JInaHOamG8pt5+Ey8kGmdcAcg3OL9reK8ltczgHTAwNhMys/6ThXHityHxVV2p3fkw/c+MAvBHFVYHFZDmjMCQ==}
     dev: false


### PR DESCRIPTION
## Summary

This PR implements a fully functional MCP (Model Context Protocol) server with stdio transport for JSON Store, exposing CRUD and query operations to AI agents. The implementation includes comprehensive validation, security hardening, observability, and testing.

Closes #6

## Changes Made

- Add MCP server bootstrap with proper stdio transport and handshake
- Implement six tools: get_doc, put_doc, rm_doc, list_ids, query, ensure_index
- Add Zod validation schemas with security-hardened regex patterns
- Prevent path traversal attacks with strict type/id validation
- Create store service adapter with 1MB document size limit and 5k list cap
- Add structured logging to stderr and in-process metrics collection
- Implement timeout handling with proper cleanup and error code tracking
- Map errors to MCP error codes (InvalidParams, RequestTimeout, InvalidRequest)
- Add console stdout pollution prevention for protocol compliance
- Support read-only mode and killswitch environment variables
- Add comprehensive test suite with 64 tests including security coverage
- Fix timer leak in timeout implementation
- Use Buffer.byteLength for accurate document size validation
- Ensure histogram metrics remain accurate after trimming

## Implementation Notes

**Architecture:**
- Split responsibilities: `schemas.ts`, `service/jsonstore.ts`, `observability/{logger.ts,metrics.ts}`, `tools.ts`, `server.ts`
- Added Zod for runtime validation with strict input/output schemas
- Normalized tool I/O to MCP spec: content array with text and json items (removed non-spec structuredContent field)

**Safety & Security:**
- Query limit capped at 1000 (default 100), skip capped at 10000
- Document size max 1MB with proper byte-level validation
- Path traversal prevention via regex patterns that reject "..", leading separators, etc.
- All logging goes to stderr via console.error; stdout reserved for protocol
- Deletion is idempotent (no error if document missing)

**Quality Improvements from Code Review:**
- Fixed timeout timer leak (timers now properly cleared with ETIMEDOUT code)
- Fixed document size validation to use Buffer.byteLength (prevents multi-byte character bypass)
- Fixed histogram metrics accuracy after trimming
- Fixed error code mapping to use proper MCP ErrorCode enum values
- Added console.info/debug redirection to prevent stdout pollution

## Follow-up Tasks

- `ensureIndex` tool is implemented but SDK Store.ensureIndex() is not yet implemented (throws "Not implemented yet")
- Consider implementing E2E tests with MCP inspector to test stdio protocol handshake
- Add metrics export endpoint or CLI command to view telemetry
- Consider adding rate limiting for tool calls to prevent abuse