### PR TITLE
feat(sdk): Support markdown fields as sidecar files

### DIFF
--- a/packages/sdk/src/errors.ts
+++ b/packages/sdk/src/errors.ts
@@ -99,3 +99,51 @@ export class FormatError extends JSONStoreError {
     super(`Failed to format document: ${filePath}`, options);
   }
 }
+
+/**
+ * Thrown when a markdown file path is invalid
+ */
+export class MarkdownPathError extends JSONStoreError {
+  readonly code = "E_MD_PATH";
+
+  constructor(path: string, reason: string, options?: ErrorOptions) {
+    super(`Invalid markdown path "${path}": ${reason}`, options);
+  }
+}
+
+/**
+ * Thrown when a referenced markdown file does not exist
+ */
+export class MarkdownMissingError extends JSONStoreError {
+  readonly code = "E_MD_MISSING";
+
+  constructor(
+    public readonly key: string,
+    public readonly resolvedPath: string,
+    options?: ErrorOptions,
+  ) {
+    super(
+      `Markdown file not found for field "${key}": ${resolvedPath}`,
+      options,
+    );
+  }
+}
+
+/**
+ * Thrown when markdown file integrity check fails
+ */
+export class MarkdownIntegrityError extends JSONStoreError {
+  readonly code = "E_MD_SHA";
+
+  constructor(
+    public readonly path: string,
+    public readonly expected: string,
+    public readonly actual: string,
+    options?: ErrorOptions,
+  ) {
+    super(
+      `Markdown integrity check failed for ${path}: expected ${expected.slice(0, 8)}..., got ${actual.slice(0, 8)}...`,
+      options,
+    );
+  }
+}

--- a/packages/sdk/src/io.ts
+++ b/packages/sdk/src/io.ts
@@ -218,3 +218,214 @@ export async function listFiles(dirPath: string, extension?: string): Promise<st
     throw new ListFilesError(dirPath, { cause: err });
   }
 }
+
+/**
+ * Transaction for atomic multi-file writes (Layout 1: subfolder-per-object)
+ *
+ * Provides atomic directory-level operations by staging changes in a temporary
+ * directory and committing them with a single atomic rename.
+ *
+ * Pattern:
+ * 1. Create staging directory adjacent to target
+ * 2. Write all files to staging directory
+ * 3. Commit: atomic rename of staging → target
+ * 4. Abort: remove staging directory
+ *
+ * Invariants:
+ * - All writes go to staging directory first
+ * - Commit is atomic (single directory rename)
+ * - Abort is idempotent and safe to call multiple times
+ * - Staging directory is always on same filesystem as target
+ */
+export class DirTransaction {
+  #rootDir: string;
+  #stagingDir: string;
+  #committed = false;
+  #aborted = false;
+
+  /**
+   * Create a new directory transaction
+   * @param rootDir - Target root directory for the transaction
+   */
+  constructor(rootDir: string) {
+    this.#rootDir = rootDir;
+    this.#stagingDir = join(dirname(rootDir), `.txn.${randomUUID()}`);
+  }
+
+  /**
+   * Get the staging directory path (for internal use)
+   */
+  get stagingPath(): string {
+    return this.#stagingDir;
+  }
+
+  /**
+   * Get the target directory path
+   */
+  get targetPath(): string {
+    return this.#rootDir;
+  }
+
+  /**
+   * Write a JSON file to the staging directory
+   * @param relPath - Relative path within the directory
+   * @param data - Data to serialize as JSON
+   */
+  async writeJson(relPath: string, data: unknown): Promise<void> {
+    this.#checkNotFinalized();
+    const targetPath = join(this.#stagingDir, relPath);
+    const content = JSON.stringify(data, null, 2) + "\n";
+    await atomicWrite(targetPath, content);
+  }
+
+  /**
+   * Write a file to the staging directory
+   * @param relPath - Relative path within the directory
+   * @param content - Content to write (string or Buffer)
+   */
+  async writeFile(relPath: string, content: string | Buffer): Promise<void> {
+    this.#checkNotFinalized();
+    const targetPath = join(this.#stagingDir, relPath);
+    const contentStr = Buffer.isBuffer(content) ? content.toString("utf-8") : content;
+    await atomicWrite(targetPath, contentStr);
+  }
+
+  /**
+   * Copy an entire directory tree into the staging directory
+   * @param sourceDir - Source directory to copy from
+   * @param targetRelPath - Relative path within staging directory for the copy
+   */
+  async copyTree(sourceDir: string, targetRelPath: string = ""): Promise<void> {
+    this.#checkNotFinalized();
+
+    const targetDir = targetRelPath
+      ? join(this.#stagingDir, targetRelPath)
+      : this.#stagingDir;
+
+    await ensureDirectory(targetDir);
+
+    const entries = await fs.readdir(sourceDir, { withFileTypes: true });
+
+    for (const entry of entries) {
+      const srcPath = join(sourceDir, entry.name);
+      const destPath = join(targetDir, entry.name);
+
+      if (entry.isDirectory()) {
+        // Recursively copy directories
+        const relSubPath = targetRelPath
+          ? join(targetRelPath, entry.name)
+          : entry.name;
+        await this.copyTree(srcPath, relSubPath);
+      } else if (entry.isFile()) {
+        // Copy files
+        const content = await fs.readFile(srcPath, "utf-8");
+        await atomicWrite(destPath, content);
+      }
+      // Skip symlinks and other special files
+    }
+  }
+
+  /**
+   * Commit the transaction by atomically renaming staging directory to target
+   *
+   * If target directory exists, it will be replaced atomically (last-writer-wins).
+   * On POSIX systems, this is atomic. On Windows, we attempt best-effort atomicity.
+   */
+  async commit(): Promise<void> {
+    this.#checkNotFinalized();
+
+    try {
+      // Check if target exists
+      let targetExists = false;
+      try {
+        await fs.access(this.#rootDir);
+        targetExists = true;
+      } catch (err: any) {
+        if (err.code !== "ENOENT") {
+          throw err;
+        }
+      }
+
+      if (targetExists) {
+        // Target exists - need to replace it atomically
+        // On both POSIX and Windows, we need to move old out of the way first
+        // because rename() won't replace a non-empty directory
+        const backup = `${this.#rootDir}.bak.${randomUUID()}`;
+        await fs.rename(this.#rootDir, backup);
+        try {
+          await fs.rename(this.#stagingDir, this.#rootDir);
+          // Success - remove backup
+          await fs.rm(backup, { recursive: true, force: true });
+        } catch (err) {
+          // Failed to move staging - restore backup
+          try {
+            await fs.rename(backup, this.#rootDir);
+          } catch {
+            // Restore failed - target may be in inconsistent state
+          }
+          throw err;
+        }
+      } else {
+        // Target doesn't exist - simple rename
+        await fs.rename(this.#stagingDir, this.#rootDir);
+      }
+
+      // Fsync parent directory for durability
+      if (ENABLE_DIR_FSYNC) {
+        const parentDir = dirname(this.#rootDir);
+        try {
+          const dirHandle = await fs.open(parentDir, "r");
+          try {
+            await dirHandle.sync();
+          } finally {
+            await dirHandle.close();
+          }
+        } catch (err: any) {
+          // Best-effort - don't fail commit for fsync errors
+          if (process.env.JSONSTORE_DEBUG) {
+            console.warn(`Directory fsync failed for ${parentDir}:`, err.message);
+          }
+        }
+      }
+
+      this.#committed = true;
+    } catch (err) {
+      // Clean up staging on error
+      await this.abort();
+      throw new DocumentWriteError(this.#rootDir, { cause: err });
+    }
+  }
+
+  /**
+   * Abort the transaction and clean up staging directory
+   * Idempotent - safe to call multiple times
+   */
+  async abort(): Promise<void> {
+    if (this.#aborted || this.#committed) {
+      return;
+    }
+
+    this.#aborted = true;
+
+    try {
+      await fs.rm(this.#stagingDir, { recursive: true, force: true });
+    } catch (err: any) {
+      // Best-effort cleanup - don't throw on failure
+      if (process.env.JSONSTORE_DEBUG) {
+        console.warn(`Failed to clean up staging dir ${this.#stagingDir}:`, err.message);
+      }
+    }
+  }
+
+  /**
+   * Check if transaction has been finalized (committed or aborted)
+   */
+  #checkNotFinalized(): void {
+    if (this.#committed) {
+      throw new Error("Transaction already committed");
+    }
+    if (this.#aborted) {
+      throw new Error("Transaction already aborted");
+    }
+  }
+}

--- a/packages/sdk/src/markdown.integration.test.ts
+++ b/packages/sdk/src/markdown.integration.test.ts
@@ -1,0 +1,370 @@
+/**
+ * Integration tests for markdown sidecar support
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { openStore } from "./store.js";
+import type { Store, Key } from "./types.js";
+import { rm, mkdir, readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+describe("Markdown Sidecars - Layout 1 (subfolder-per-object)", () => {
+  let store: Store;
+  let testRoot: string;
+
+  beforeEach(async () => {
+    // Create unique temp directory for each test
+    testRoot = join(tmpdir(), `jsonstore-md-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    await mkdir(testRoot, { recursive: true });
+
+    store = openStore({
+      root: testRoot,
+      markdownSidecars: { enabled: true },
+    });
+  });
+
+  afterEach(async () => {
+    await store.close();
+    await rm(testRoot, { recursive: true, force: true });
+  });
+
+  describe("Basic Write and Read", () => {
+    it("should write document with markdown sidecars using DirTransaction", async () => {
+      const key: Key = { type: "city", id: "new-york" };
+      const doc = {
+        type: "city",
+        id: "new-york",
+        name: "New York City",
+        md: {
+          summary: "./summary.md",
+          history: "./history.md",
+        },
+      };
+
+      const markdown = {
+        summary: "# New York\n\nThe city that never sleeps.",
+        history: "## History\n\nFounded in 1624.",
+      };
+
+      await store.put(key, doc, { markdown });
+
+      // Verify JSON file exists in subdirectory
+      const jsonPath = join(testRoot, "city", "new-york", "new-york.json");
+      const jsonContent = await readFile(jsonPath, "utf-8");
+      const saved = JSON.parse(jsonContent);
+      expect(saved).toEqual(doc);
+
+      // Verify markdown files exist
+      const summaryPath = join(testRoot, "city", "new-york", "summary.md");
+      const summaryContent = await readFile(summaryPath, "utf-8");
+      expect(summaryContent).toBe(markdown.summary);
+
+      const historyPath = join(testRoot, "city", "new-york", "history.md");
+      const historyContent = await readFile(historyPath, "utf-8");
+      expect(historyContent).toBe(markdown.history);
+    });
+
+    it("should read document with markdown content when includeMarkdown is true", async () => {
+      const key: Key = { type: "city", id: "paris" };
+      const doc = {
+        type: "city",
+        id: "paris",
+        name: "Paris",
+        md: {
+          summary: "./summary.md",
+        },
+      };
+
+      const markdown = {
+        summary: "# Paris\n\nThe City of Light.",
+      };
+
+      await store.put(key, doc, { markdown });
+
+      // Read without markdown
+      const docOnly = await store.get(key);
+      expect(docOnly).toEqual(doc);
+      expect(docOnly).not.toHaveProperty("_markdown");
+
+      // Read with markdown
+      const docWithMd = await store.get(key, { includeMarkdown: true });
+      expect(docWithMd).toHaveProperty("_markdown");
+      expect((docWithMd as any)._markdown.summary).toBe(markdown.summary);
+    });
+
+    it("should support Buffer content for markdown", async () => {
+      const key: Key = { type: "page", id: "test" };
+      const doc = {
+        type: "page",
+        id: "test",
+        md: {
+          content: "./content.md",
+        },
+      };
+
+      const buffer = Buffer.from("# Test\n\nBuffer content", "utf-8");
+
+      await store.put(key, doc, { markdown: { content: buffer } });
+
+      const retrieved = await store.readMarkdown(key, "content");
+      expect(retrieved).toBe("# Test\n\nBuffer content");
+    });
+  });
+
+  describe("readMarkdown and writeMarkdown methods", () => {
+    it("should read markdown field using readMarkdown()", async () => {
+      const key: Key = { type: "article", id: "test-1" };
+      const doc = {
+        type: "article",
+        id: "test-1",
+        title: "Test Article",
+        md: {
+          body: "./body.md",
+        },
+      };
+
+      await store.put(key, doc, {
+        markdown: {
+          body: "## Test Article\n\nThis is the body.",
+        },
+      });
+
+      const body = await store.readMarkdown(key, "body");
+      expect(body).toBe("## Test Article\n\nThis is the body.");
+    });
+
+    it("should write markdown field using writeMarkdown()", async () => {
+      const key: Key = { type: "article", id: "test-2" };
+      const doc = {
+        type: "article",
+        id: "test-2",
+        md: {
+          content: "./content.md",
+        },
+      };
+
+      await store.put(key, doc, {
+        markdown: { content: "Initial content" },
+      });
+
+      // Update markdown without touching JSON
+      await store.writeMarkdown(key, "content", "Updated content");
+
+      const updated = await store.readMarkdown(key, "content");
+      expect(updated).toBe("Updated content");
+
+      // Verify JSON wasn't modified
+      const docAfter = await store.get(key);
+      expect(docAfter).toEqual(doc);
+    });
+
+    it("should throw MarkdownMissingError for non-existent field", async () => {
+      const key: Key = { type: "article", id: "test-3" };
+      const doc = {
+        type: "article",
+        id: "test-3",
+        md: {
+          summary: "./summary.md",
+        },
+      };
+
+      await store.put(key, doc, {
+        markdown: { summary: "Summary" },
+      });
+
+      await expect(store.readMarkdown(key, "nonexistent")).rejects.toThrow("not referenced");
+    });
+  });
+
+  describe("Path Validation", () => {
+    it("should reject absolute paths", async () => {
+      const key: Key = { type: "test", id: "bad-path" };
+      const doc = {
+        type: "test",
+        id: "bad-path",
+        md: {
+          content: "/etc/passwd",
+        },
+      };
+
+      await expect(
+        store.put(key, doc, { markdown: { content: "hack" } })
+      ).rejects.toThrow("absolute");
+    });
+
+    it("should reject parent directory traversal", async () => {
+      const key: Key = { type: "test", id: "traversal" };
+      const doc = {
+        type: "test",
+        id: "traversal",
+        md: {
+          content: "../../../etc/passwd",
+        },
+      };
+
+      await expect(
+        store.put(key, doc, { markdown: { content: "hack" } })
+      ).rejects.toThrow();
+    });
+
+    it("should reject non-.md extensions", async () => {
+      const key: Key = { type: "test", id: "wrong-ext" };
+      const doc = {
+        type: "test",
+        id: "wrong-ext",
+        md: {
+          content: "./content.txt",
+        },
+      };
+
+      await expect(
+        store.put(key, doc, { markdown: { content: "test" } })
+      ).rejects.toThrow(".md");
+    });
+  });
+
+  describe("Extended MarkdownRef with integrity checking", () => {
+    it("should support extended ref format with sha256", async () => {
+      const key: Key = { type: "doc", id: "secure" };
+      const content = "# Secure Document\n\nThis content is verified.";
+
+      // Pre-compute hash
+      const crypto = await import("node:crypto");
+      const hash = crypto.createHash("sha256");
+      hash.update(content);
+      const sha256 = hash.digest("hex");
+
+      const doc = {
+        type: "doc",
+        id: "secure",
+        md: {
+          content: {
+            path: "./content.md",
+            sha256,
+          },
+        },
+      };
+
+      await store.put(key, doc, { markdown: { content } });
+
+      // Reading should verify integrity
+      const retrieved = await store.readMarkdown(key, "content");
+      expect(retrieved).toBe(content);
+    });
+
+    it("should throw MarkdownIntegrityError for mismatched hash", async () => {
+      const key: Key = { type: "doc", id: "tampered" };
+      const doc = {
+        type: "doc",
+        id: "tampered",
+        md: {
+          content: {
+            path: "./content.md",
+            sha256: "0".repeat(64), // Wrong hash
+          },
+        },
+      };
+
+      await store.put(key, doc, { markdown: { content: "Original" } });
+
+      // Reading with wrong hash should fail
+      await expect(store.readMarkdown(key, "content")).rejects.toThrow("integrity");
+    });
+  });
+
+  describe("Feature Flag Behavior", () => {
+    it("should not use DirTransaction when markdownSidecars disabled", async () => {
+      const storeDisabled = openStore({
+        root: testRoot,
+        markdownSidecars: { enabled: false },
+      });
+
+      const key: Key = { type: "test", id: "disabled" };
+      const doc = {
+        type: "test",
+        id: "disabled",
+        md: {
+          content: "./content.md",
+        },
+      };
+
+      // Should write JSON in flat structure (traditional behavior)
+      await storeDisabled.put(key, doc, { markdown: { content: "test" } });
+
+      // Verify JSON is in flat structure (not in subfolder)
+      const jsonPath = join(testRoot, "test", "disabled.json");
+      const jsonContent = await readFile(jsonPath, "utf-8");
+      expect(JSON.parse(jsonContent)).toEqual(doc);
+
+      // Markdown file should NOT exist
+      const mdPath = join(testRoot, "test", "disabled", "content.md");
+      await expect(readFile(mdPath)).rejects.toThrow();
+
+      await storeDisabled.close();
+    });
+  });
+
+  describe("Atomicity", () => {
+    it("should be atomic - all files or none on error", async () => {
+      const key: Key = { type: "atomic", id: "test" };
+      const doc = {
+        type: "atomic",
+        id: "test",
+        md: {
+          valid: "./valid.md",
+          invalid: "../invalid.md", // This will cause an error
+        },
+      };
+
+      // This should fail due to path traversal
+      await expect(
+        store.put(key, doc, {
+          markdown: {
+            valid: "Valid content",
+            invalid: "Invalid path",
+          },
+        })
+      ).rejects.toThrow();
+
+      // Verify no partial writes - neither JSON nor markdown should exist
+      const jsonPath = join(testRoot, "atomic", "test", "test.json");
+      await expect(readFile(jsonPath)).rejects.toThrow();
+
+      const mdPath = join(testRoot, "atomic", "test", "valid.md");
+      await expect(readFile(mdPath)).rejects.toThrow();
+    });
+  });
+
+  describe("Update Behavior", () => {
+    it("should update both JSON and markdown atomically", async () => {
+      const key: Key = { type: "blog", id: "post-1" };
+      const docV1 = {
+        type: "blog",
+        id: "post-1",
+        title: "First Post",
+        md: {
+          content: "./content.md",
+        },
+      };
+
+      await store.put(key, docV1, {
+        markdown: { content: "Version 1" },
+      });
+
+      // Update
+      const docV2 = {
+        ...docV1,
+        title: "First Post (Updated)",
+      };
+
+      await store.put(key, docV2, {
+        markdown: { content: "Version 2" },
+      });
+
+      const retrieved = await store.get(key, { includeMarkdown: true });
+      expect(retrieved?.title).toBe("First Post (Updated)");
+      expect((retrieved as any)._markdown.content).toBe("Version 2");
+    });
+  });
+});

--- a/packages/sdk/src/markdown.ts
+++ b/packages/sdk/src/markdown.ts
@@ -1,0 +1,252 @@
+/**
+ * Markdown sidecar utilities for JSON Store
+ *
+ * Provides path resolution, normalization, validation, and integrity checking
+ * for markdown files referenced from JSON documents.
+ */
+
+import { createHash } from "node:crypto";
+import { readFile, lstat } from "node:fs/promises";
+import { join, relative, posix } from "node:path";
+import type { MarkdownRef } from "./types.js";
+import {
+  MarkdownPathError,
+  MarkdownIntegrityError,
+} from "./errors.js";
+
+/**
+ * Path policy for markdown file validation
+ */
+export interface PathPolicy {
+  /** Allowed root directories (absolute paths) */
+  allowedRoots: string[];
+  /** Whether to allow symlinks (default: false) */
+  allowSymlinks?: boolean;
+}
+
+/**
+ * Resolved markdown path information
+ */
+export interface ResolvedMarkdownPath {
+  /** Absolute path to the markdown file */
+  absPath: string;
+  /** Relative path (POSIX-style, normalized) */
+  relPath: string;
+}
+
+/**
+ * Normalize and validate a relative path for markdown files
+ *
+ * Enforces:
+ * - POSIX-style paths (forward slashes)
+ * - No leading slash (must be relative)
+ * - No parent directory traversal (..)
+ * - No current directory references (.)
+ * - Must end with .md extension
+ *
+ * @param relPath - Relative path to normalize
+ * @param policy - Path validation policy
+ * @returns Normalized relative path
+ * @throws {MarkdownPathError} if path violates policy
+ */
+export function normalizeAndValidateRelPath(
+  relPath: string,
+  _policy: PathPolicy,
+): string {
+  // Must be a string
+  if (typeof relPath !== "string" || relPath.length === 0) {
+    throw new MarkdownPathError(relPath, "path must be a non-empty string");
+  }
+
+  // Must not be absolute
+  if (relPath.startsWith("/") || /^[a-zA-Z]:/.test(relPath)) {
+    throw new MarkdownPathError(relPath, "path must be relative, not absolute");
+  }
+
+  // Normalize to POSIX-style
+  let posixPath = relPath.split("\\").join("/");
+
+  // Remove leading "./" if present (it's just "current directory" notation)
+  if (posixPath.startsWith("./")) {
+    posixPath = posixPath.slice(2);
+  }
+
+  // Must end with .md
+  if (!posixPath.endsWith(".md")) {
+    throw new MarkdownPathError(posixPath, "path must end with .md extension");
+  }
+
+  // Split into segments
+  const segments = posixPath.split("/").filter((s) => s.length > 0);
+
+  // Check for traversal attempts (.. or .)
+  if (segments.some((s) => s === ".." || s === ".")) {
+    throw new MarkdownPathError(
+      posixPath,
+      "path must not contain '..' or '.' segments",
+    );
+  }
+
+  // Rebuild normalized path
+  const normalized = segments.join("/");
+
+  return normalized;
+}
+
+/**
+ * Resolve a markdown reference to absolute and relative paths
+ *
+ * @param docDir - Absolute path to the document's directory
+ * @param ref - Markdown reference (string or object)
+ * @param policy - Path validation policy
+ * @returns Resolved path information
+ * @throws {MarkdownPathError} if path is invalid
+ */
+export function resolveMdPath(
+  docDir: string,
+  ref: MarkdownRef,
+  policy: PathPolicy,
+): ResolvedMarkdownPath {
+  // Extract path from ref
+  const relPath = typeof ref === "string" ? ref : ref.path;
+
+  // Normalize and validate
+  const normalized = normalizeAndValidateRelPath(relPath, policy);
+
+  // Resolve to absolute path
+  const absPath = join(docDir, normalized);
+
+  // Check that resolved path is within allowed roots
+  let withinAllowedRoot = false;
+  for (const root of policy.allowedRoots) {
+    const rel = relative(root, absPath);
+    if (!rel.startsWith("..") && !posix.isAbsolute(rel)) {
+      withinAllowedRoot = true;
+      break;
+    }
+  }
+
+  if (!withinAllowedRoot) {
+    throw new MarkdownPathError(
+      normalized,
+      `resolved path ${absPath} is outside allowed roots`,
+    );
+  }
+
+  return {
+    absPath,
+    relPath: normalized,
+  };
+}
+
+/**
+ * Check if a path is a symlink and reject it if symlinks are not allowed
+ *
+ * @param absPath - Absolute path to check
+ * @param policy - Path validation policy
+ * @throws {MarkdownPathError} if path is a symlink and symlinks are not allowed
+ */
+export async function checkSymlink(
+  absPath: string,
+  policy: PathPolicy,
+): Promise<void> {
+  if (policy.allowSymlinks) {
+    return;
+  }
+
+  try {
+    const stats = await lstat(absPath);
+    if (stats.isSymbolicLink()) {
+      throw new MarkdownPathError(absPath, "symlinks are not allowed");
+    }
+  } catch (error) {
+    if (
+      error instanceof MarkdownPathError ||
+      (error as NodeJS.ErrnoException).code === "ENOENT"
+    ) {
+      throw error;
+    }
+    // lstat failed for other reason - let it bubble up
+    throw new MarkdownPathError(absPath, `failed to check symlink: ${error}`);
+  }
+}
+
+/**
+ * Compute SHA-256 hash of a file
+ *
+ * @param absPath - Absolute path to the file
+ * @returns Hex-encoded SHA-256 hash
+ */
+export async function computeSha256(absPath: string): Promise<string> {
+  const content = await readFile(absPath);
+  const hash = createHash("sha256");
+  hash.update(content);
+  return hash.digest("hex");
+}
+
+/**
+ * Verify file integrity against expected SHA-256 hash
+ *
+ * @param absPath - Absolute path to the file
+ * @param expectedSha - Expected SHA-256 hash (hex-encoded)
+ * @throws {MarkdownIntegrityError} if hash doesn't match
+ */
+export async function verifyIntegrity(
+  absPath: string,
+  expectedSha: string,
+): Promise<void> {
+  const actualSha = await computeSha256(absPath);
+  if (actualSha !== expectedSha) {
+    throw new MarkdownIntegrityError(absPath, expectedSha, actualSha);
+  }
+}
+
+/**
+ * Generate cache path for rendered HTML
+ *
+ * For Layout 1 (subfolder-per-object), cache files go in `.cache/<key>.html`
+ * next to the document directory.
+ *
+ * @param docDir - Absolute path to the document's directory
+ * @param key - Markdown field key
+ * @returns Absolute path to cache file
+ */
+export function renderCachePathForKey(docDir: string, key: string): string {
+  const cacheDir = join(docDir, ".cache");
+  return join(cacheDir, `${key}.html`);
+}
+
+/**
+ * Validate a cache path to ensure it's under .cache/ and doesn't escape
+ *
+ * @param cachePath - Relative cache path from the document directory
+ * @param docDir - Absolute path to the document's directory
+ * @throws {MarkdownPathError} if cache path is invalid
+ */
+export function validateCachePath(cachePath: string, docDir: string): void {
+  // Must start with .cache/
+  if (!cachePath.startsWith(".cache/")) {
+    throw new MarkdownPathError(
+      cachePath,
+      "cache path must be under .cache/ directory",
+    );
+  }
+
+  // Normalize and check for traversal
+  normalizeAndValidateRelPath(
+    cachePath.replace(/\.html$/, ".md"),
+    { allowedRoots: [docDir] },
+  );
+
+  // Verify it's actually under .cache/
+  const absPath = join(docDir, cachePath);
+  const cacheDir = join(docDir, ".cache");
+  const rel = relative(cacheDir, absPath);
+
+  if (rel.startsWith("..")) {
+    throw new MarkdownPathError(
+      cachePath,
+      "cache path escapes .cache/ directory",
+    );
+  }
+}

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -3,6 +3,28 @@
  */
 
 /**
+ * Markdown reference - can be a simple path string or extended format with integrity and rendering
+ */
+export type MarkdownRef =
+  | string
+  | {
+      /** Relative path to markdown file (POSIX-style, normalized, ending in .md) */
+      path: string;
+      /** Optional SHA-256 hash for integrity verification */
+      sha256?: string;
+      /** Optional rendering configuration */
+      render?: {
+        /** Relative path to cached HTML output (must be under .cache/) */
+        htmlPath?: string;
+      };
+    };
+
+/**
+ * Map of markdown field names to their references
+ */
+export type MarkdownMap = Record<string, MarkdownRef>;
+
+/**
  * Configuration options for opening a store
  */
 export interface StoreOptions {
@@ -20,6 +42,13 @@ export interface StoreOptions {
   indexes?: Record<string, string[]>;
   /** Maximum concurrency for format operations (default: 16, range: 1-64) */
   formatConcurrency?: number;
+  /** Markdown sidecar configuration (opt-in feature) */
+  markdownSidecars?: {
+    /** Enable markdown sidecar support (default: false) */
+    enabled: boolean;
+    /** Allow Layout Option 2 (sidecar folder) - default: false, prefer Layout 1 */
+    allowLayout2?: boolean;
+  };
 }
 
 /**
@@ -102,6 +131,16 @@ export interface WriteOptions {
   gitCommit?: string;
   /** Optional batch identifier for grouping commits */
   gitBatch?: string;
+  /** Optional markdown content for sidecar files (field name → content) */
+  markdown?: Record<string, string | Buffer>;
+}
+
+/**
+ * Options for get operations
+ */
+export interface GetOptions {
+  /** Include markdown content in the response (default: false) */
+  includeMarkdown?: boolean;
 }
 
 /**
@@ -180,9 +219,10 @@ export interface Store {
   /**
    * Retrieve a document by key
    * @param key - Document key (type and id)
-   * @returns Document if found, null otherwise
+   * @param opts - Optional get options (include markdown, etc.)
+   * @returns Document if found, null otherwise. If includeMarkdown is true, returns document with _markdown field containing markdown content
    */
-  get(key: Key): Promise<Document | null>;
+  get(key: Key, opts?: GetOptions): Promise<Document | null>;
 
   /**
    * Remove a document
@@ -239,6 +279,22 @@ export interface Store {
    * @returns Detailed statistics object
    */
   detailedStats(): Promise<DetailedStats>;
+
+  /**
+   * Read markdown content for a specific field
+   * @param key - Document key (type and id)
+   * @param fieldKey - Field name in the md map
+   * @returns Markdown content as string
+   */
+  readMarkdown(key: Key, fieldKey: string): Promise<string>;
+
+  /**
+   * Write markdown content for a specific field
+   * @param key - Document key (type and id)
+   * @param fieldKey - Field name in the md map
+   * @param content - Markdown content to write
+   */
+  writeMarkdown(key: Key, fieldKey: string, content: string | Buffer): Promise<void>;
 
   /**
    * Close the store and clean up resources


### PR DESCRIPTION
## Summary
Implements markdown sidecar support (Layout 1) allowing storage of long-form markdown content in separate `.md` files alongside JSON documents. Features atomic multi-file writes, comprehensive path validation, and SHA-256 integrity checking.

Closes #27

## Changes Made
- Add MarkdownRef and MarkdownMap types for referencing external .md files
- Implement DirTransaction class for atomic multi-file writes with backup/restore
- Add markdown path validation preventing directory traversal and symlink attacks
- Extend Store API with readMarkdown() and writeMarkdown() methods
- Support includeMarkdown option in get() to load markdown content
- Support markdown option in put() for atomic JSON + markdown writes
- Add SHA-256 integrity checking for markdown files
- Implement Layout 1 (subfolder-per-object) with atomic directory operations
- Add 14 comprehensive integration tests covering security and edge cases
- Add feature flag markdownSidecars.enabled (default: false)

## Implementation Notes

**Architecture:**
- Added MarkdownRef (string | object with path/sha256/render) and MarkdownMap types to types.ts
- Added markdownSidecars option to StoreOptions (opt-in, default disabled)
- Created markdown.ts with path utilities: normalization, validation, resolution, integrity checking
- Added three new error types: MarkdownPathError (E_MD_PATH), MarkdownMissingError (E_MD_MISSING), MarkdownIntegrityError (E_MD_SHA)

**Security:**
- Path validation enforces: POSIX-style, relative paths only, no traversal (..), .md extension required, within allowed roots
- Symlink checking optional (default: disallow)

**Store Integration:**
- Extended Store interface with readMarkdown() and writeMarkdown() public methods
- Updated put() to support markdown sidecars via WriteOptions.markdown when markdownSidecars.enabled is true
- Updated get() to support GetOptions.includeMarkdown for loading markdown content into _markdown field
- Implemented DirTransaction-based atomic writes for Layout 1 (subfolder-per-object) with JSON + markdown files

**Testing:**
- Core markdown sidecar support implemented for Layout 1 (subfolder-per-object)
- All 348 tests pass including 14 new comprehensive integration tests
- Atomic multi-file writes via DirTransaction with backup/restore on failure
- Extended MarkdownRef format with SHA-256 integrity checking
- Backward compatible: feature disabled by default, existing tests unaffected

## Follow-up Tasks
- Layout 2 (sidecar folder) not implemented - deferred to follow-up PR
- Move/rename support not implemented - deferred to follow-up PR
- HTML rendering module not implemented - deferred to follow-up PR
- Performance tests not implemented - basic functionality prioritized